### PR TITLE
Add TagEnum encoding

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -28,7 +28,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 	switch value.(type) {
 	case int:
 		if tag != TagInteger && tag != TagEnum {
-			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
+			return fmt.Errorf("tag for attribute %s does not match with value type", attribute)
 		}
 
 		if err := e.encodeTag(tag); err != nil {
@@ -44,7 +44,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 		}
 	case int16:
 		if tag != TagInteger && tag != TagEnum {
-			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
+			return fmt.Errorf("tag for attribute %s does not match with value type", attribute)
 		}
 
 		if err := e.encodeTag(tag); err != nil {
@@ -60,7 +60,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 		}
 	case int8:
 		if tag != TagInteger && tag != TagEnum {
-			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
+			return fmt.Errorf("tag for attribute %s does not match with value type", attribute)
 		}
 
 		if err := e.encodeTag(tag); err != nil {
@@ -76,7 +76,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 		}
 	case int32:
 		if tag != TagInteger && tag != TagEnum {
-			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
+			return fmt.Errorf("tag for attribute %s does not match with value type", attribute)
 		}
 
 		if err := e.encodeTag(tag); err != nil {
@@ -92,7 +92,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 		}
 	case int64:
 		if tag != TagInteger && tag != TagEnum {
-			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
+			return fmt.Errorf("tag for attribute %s does not match with value type", attribute)
 		}
 
 		if err := e.encodeTag(tag); err != nil {
@@ -108,7 +108,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 		}
 	case []int:
 		if tag != TagInteger && tag != TagEnum {
-			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
+			return fmt.Errorf("tag for attribute %s does not match with value type", attribute)
 		}
 
 		for index, val := range value.([]int) {
@@ -132,7 +132,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 		}
 	case []int16:
 		if tag != TagInteger && tag != TagEnum {
-			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
+			return fmt.Errorf("tag for attribute %s does not match with value type", attribute)
 		}
 
 		for index, val := range value.([]int16) {
@@ -156,7 +156,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 		}
 	case []int8:
 		if tag != TagInteger && tag != TagEnum {
-			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
+			return fmt.Errorf("tag for attribute %s does not match with value type", attribute)
 		}
 
 		for index, val := range value.([]int8) {
@@ -180,7 +180,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 		}
 	case []int32:
 		if tag != TagInteger && tag != TagEnum {
-			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
+			return fmt.Errorf("tag for attribute %s does not match with value type", attribute)
 		}
 
 		for index, val := range value.([]int32) {
@@ -204,7 +204,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 		}
 	case []int64:
 		if tag != TagInteger && tag != TagEnum {
-			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
+			return fmt.Errorf("tag for attribute %s does not match with value type", attribute)
 		}
 
 		for index, val := range value.([]int64) {
@@ -228,7 +228,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 		}
 	case bool:
 		if tag != TagBoolean {
-			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
+			return fmt.Errorf("tag for attribute %s does not match with value type", attribute)
 		}
 
 		if err := e.encodeTag(tag); err != nil {
@@ -244,7 +244,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 		}
 	case []bool:
 		if tag != TagBoolean {
-			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
+			return fmt.Errorf("tag for attribute %s does not match with value type", attribute)
 		}
 
 		for index, val := range value.([]bool) {

--- a/attribute.go
+++ b/attribute.go
@@ -27,7 +27,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 
 	switch value.(type) {
 	case int:
-		if tag != TagInteger {
+		if tag != TagInteger && tag != TagEnum {
 			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
 		}
 
@@ -43,7 +43,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 			return err
 		}
 	case int16:
-		if tag != TagInteger {
+		if tag != TagInteger && tag != TagEnum {
 			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
 		}
 
@@ -59,7 +59,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 			return err
 		}
 	case int8:
-		if tag != TagInteger {
+		if tag != TagInteger && tag != TagEnum {
 			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
 		}
 
@@ -75,7 +75,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 			return err
 		}
 	case int32:
-		if tag != TagInteger {
+		if tag != TagInteger && tag != TagEnum {
 			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
 		}
 
@@ -91,7 +91,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 			return err
 		}
 	case int64:
-		if tag != TagInteger {
+		if tag != TagInteger && tag != TagEnum {
 			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
 		}
 
@@ -107,7 +107,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 			return err
 		}
 	case []int:
-		if tag != TagInteger {
+		if tag != TagInteger && tag != TagEnum {
 			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
 		}
 
@@ -131,7 +131,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 			}
 		}
 	case []int16:
-		if tag != TagInteger {
+		if tag != TagInteger && tag != TagEnum {
 			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
 		}
 
@@ -155,7 +155,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 			}
 		}
 	case []int8:
-		if tag != TagInteger {
+		if tag != TagInteger && tag != TagEnum {
 			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
 		}
 
@@ -179,7 +179,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 			}
 		}
 	case []int32:
-		if tag != TagInteger {
+		if tag != TagInteger && tag != TagEnum {
 			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
 		}
 
@@ -203,7 +203,7 @@ func (e *AttributeEncoder) Encode(attribute string, value interface{}) error {
 			}
 		}
 	case []int64:
-		if tag != TagInteger {
+		if tag != TagInteger && tag != TagEnum {
 			return fmt.Errorf("tag for attribte %s does not match with value type", attribute)
 		}
 

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -35,6 +35,11 @@ var attributeTestCases = []struct {
 		Value:     "utf-8",
 		Bytes:     []byte{71, 0, 18, 97, 116, 116, 114, 105, 98, 117, 116, 101, 115, 45, 99, 104, 97, 114, 115, 101, 116, 0, 5, 117, 116, 102, 45, 56},
 	},
+	{
+		Attribute: "printer-state",
+		Value:     3,
+		Bytes:     []byte("\x23\x00\x0dprinter-state\x00\x04\x00\x00\x00\x03"),
+	},
 }
 
 func TestAttributeEncoding(t *testing.T) {


### PR DESCRIPTION
I need to specify the job attribute landscape mode printing. I can define the relevant attribute:

```go
func init() {
	ipp.AttributeTagMapping["orientation-requested"] = ipp.TagEnum
}
```

I can then specify landscape (4) as a job attribute in a completely custom request, but encoding this request fails:

```
tag for attribte orientation-requested does not match with value type
```

This PR allows `go-ipp` to encode enumerations, clearing the blocker for my use case. It adds a test case for encoding/decoding enumerations. It also fixes the typo in the error message above.