### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 To get the package, execute:
 ```
-go get -h github.com/phin1x/go-ipp
+go get -u github.com/phin1x/go-ipp
 ```
 
 ## Features


### PR DESCRIPTION
I assume this is a typo, as `-h` isn't a valid parameter.