### PR TITLE
use int32 instead of int when parsing

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -351,8 +351,8 @@ type Attribute struct {
 
 // Resolution defines the resolution attribute
 type Resolution struct {
-	Height int
-	Width  int
+	Height int32
+	Width  int32
 	Depth  int8
 }
 
@@ -480,7 +480,7 @@ func (d *AttributeDecoder) decodeDate() ([]int, error) {
 	return is, nil
 }
 
-func (d *AttributeDecoder) decodeRange() ([]int, error) {
+func (d *AttributeDecoder) decodeRange() ([]int32, error) {
 	length, err := d.readValueLength()
 	if err != nil {
 		return nil, err
@@ -488,10 +488,10 @@ func (d *AttributeDecoder) decodeRange() ([]int, error) {
 
 	// initialize range element count (c) and range slice (r)
 	c := length / 4
-	r := make([]int, c)
+	r := make([]int32, c)
 
 	for i := int16(0); i < c; i++ {
-		var ti int
+		var ti int32
 		if err = binary.Read(d.reader, binary.BigEndian, &ti); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This fixes some parsing issues I've been having. In particular I'm using a `OperationCupsGetPrinters` request which returns all attributes for all printers. I was getting various errors like `binary.Read: invalid type *int`. Ultimately I discovered it was because in a few places `int` was used instead of `int32`. I'm on amd64, where `int` is (at least sometimes) 64bits instead of 32. 

If the change to the public API of `Resolution` is unacceptable, I can rewrite the `decodeResolution` function to use the correct type privately.