### PR TITLE
Encode required operation attributes first

### DIFF
--- a/request.go
+++ b/request.go
@@ -71,10 +71,8 @@ func (r *Request) Encode() ([]byte, error) {
 	}
 
 	if len(r.OperationAttributes) > 0 {
-		for attr, value := range r.OperationAttributes {
-			if err := enc.Encode(attr, value); err != nil {
-				return nil, err
-			}
+		if err := r.encodeOperationAttributes(enc); err != nil {
+			return nil, err
 		}
 	}
 
@@ -105,6 +103,31 @@ func (r *Request) Encode() ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+func (r *Request) encodeOperationAttributes(enc *AttributeEncoder) error {
+	ordered := []string{
+		AttributeCharset,
+		AttributeNaturalLanguage,
+		AttributePrinterURI,
+		AttributeJobID,
+	}
+
+	for _, attr := range ordered {
+		if value, ok := r.OperationAttributes[attr]; ok {
+			delete(r.OperationAttributes, attr)
+			if err := enc.Encode(attr, value); err != nil {
+				return err
+			}
+		}
+	}
+
+	for attr, value := range r.OperationAttributes {
+		if err := enc.Encode(attr, value); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // RequestDecoder reads and decodes a request from a stream


### PR DESCRIPTION
I've been using this module to do direct printing to an IPP printer and noticed a bug in the way operation attributes are encoded. It results in intermittent "bad request" responses from the printer. This is because some operation attributes must be encoded first, in the right order, before any others.

From https://www.pwg.org/ipp/ippguide.html#ipp-message-encoding

> The first two attributes in an IPP message are always:
> 1. "attributes-charset" which defines the character set to use for all name and text strings, and
> 2. "attributes-natural-language" which defines the default language for those strings, e.g., "en" for English, "fr" for French, "ja" for Japanese, etc.

> The next attributes must be the Printer's URI ("printer-uri") and, if the request is targeting a print job, the job's ID number ("job-id").

This change makes sure that these operation attributes are encoded first, if present. However, all except for `job-id` are **requred** it seems like, so not sure if you want to also enforce these attributes or leave it up to the caller?