### PR TITLE
Add printer-is-temporary attribute

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -310,6 +310,7 @@ const (
 	AttributePPDName                 = "ppd-name"
 	AttributePPDMakeAndModel         = "ppd-make-and-model"
 	AttributePrinterIsShared         = "printer-is-shared"
+	AttributePrinterIsTemporary      = "printer-is-temporary"
 	AttributePrinterURI              = "printer-uri"
 	AttributePurgeJobs               = "purge-jobs"
 	AttributeRequestedAttributes     = "requested-attributes"
@@ -408,6 +409,7 @@ var (
 		AttributePrinterInfo:             TagText,
 		AttributePrinterIsAcceptingJobs:  TagBoolean,
 		AttributePrinterIsShared:         TagBoolean,
+		AttributePrinterIsTemporary:      TagBoolean,
 		AttributePrinterName:             TagName,
 		AttributePrinterLocation:         TagText,
 		AttributePrinterResolution:       TagResolution,


### PR DESCRIPTION
This adds the `printer-is-temporary` attribute which was added to CUPs [here](https://github.com/apple/cups/commit/12b798a070bd54d9bc5c32d57acd547cac82e494).